### PR TITLE
Change prepare button order

### DIFF
--- a/app/controllers/ovens_controller.rb
+++ b/app/controllers/ovens_controller.rb
@@ -6,7 +6,7 @@ class OvensController < ApplicationController
   end
 
   def show
-    @oven = current_user.ovens.find_by!(id: params[:id])
+    @oven = current_user.ovens.includes(:cookies).find_by!(id: params[:id])
   end
 
   def empty

--- a/app/helpers/oven_helper.rb
+++ b/app/helpers/oven_helper.rb
@@ -1,0 +1,6 @@
+module OvenHelper
+  def retrieve_cookies_button
+    hide_class = 'hide' unless @oven.all_cookies_ready?
+    button_to "Retrieve Cookie", empty_oven_path(@oven), class: "empty-oven button tiny #{hide_class}"
+  end
+end

--- a/app/views/ovens/show.html.haml
+++ b/app/views/ovens/show.html.haml
@@ -1,22 +1,14 @@
-.oven-desktop
-  %h3= @oven.name
-
-  - @oven.cookies.each do |cookie|
-    .cookie-info{ data: { cookie_id: cookie.id } }
-      = render partial: 'cookie_info', locals: { cookie: cookie }
-
-  %br
-  = button_to "Retrieve Cookie", empty_oven_path(@oven), class: 'empty-oven button tiny hide'
-
-  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
+%h3= @oven.name
 
 .oven-mobile
-  %h3= @oven.name
-
   = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'button'
-  - @oven.cookies.each do |cookie|
-    .cookie-info{ data: { cookie_id: cookie.id } }
-      = render partial: 'cookie_info', locals: { cookie: cookie }
 
-  %br
-  = button_to "Retrieve Cookie", empty_oven_path(@oven), class: 'empty-oven button tiny hide'
+- @oven.cookies.each do |cookie|
+  .cookie-info{ data: { cookie_id: cookie.id } }
+    = render partial: 'cookie_info', locals: { cookie: cookie }
+
+%br
+= retrieve_cookies_button
+
+.oven-desktop
+  = link_to "Prepare Cookie", new_oven_cookies_path(@oven), class: 'prepare-cookies button'

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -8,7 +8,7 @@ feature 'Cooking cookies' do
     expect(page).to_not have_content 'Chocolate Chip'
     expect(page).to_not have_content 'Your Cookie is Ready'
 
-    click_link_or_button 'Prepare Cookie'
+    find('.oven-desktop').click_link_or_button('Prepare Cookie')
     fill_in 'Fillings', with: 'Chocolate Chip'
     click_button 'Mix and bake'
 
@@ -24,11 +24,11 @@ feature 'Cooking cookies' do
     oven = FactoryGirl.create(:oven, user: user)
     visit oven_path(oven)
 
-    click_link_or_button 'Prepare Cookie'
+    find('.oven-desktop').click_link_or_button('Prepare Cookie')
     fill_in 'Fillings', with: 'Chocolate Chip'
     click_button 'Mix and bake'
 
-    click_link_or_button  'Prepare Cookie'
+    find('.oven-desktop').click_link_or_button('Prepare Cookie')
     expect(page).to have_content 'A set of cookies are already in the oven!'
     expect(current_path).to eq(oven_path(oven))
     expect(page).to_not have_button 'Mix and bake'


### PR DESCRIPTION
- Show the button for preparing the cookies from the bottom to the top on mobile versions.

**Changes not related with the purpose of this PR**
- Fix n+1 when loading the oven